### PR TITLE
Adding snap-toggle attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ In your view:
 The `snap-contents` directive will watch your `snap-options` object for runtime
 changes and update itself as you make them.
 
+
+### `snap-toggle`
+
+Used to easily make a button toggle the snap status.
+
+```html
+<button snap-toggle="left">Toggle Snap</button>
+```
+
 ## Live Examples
 
 _(more coming soon)_

--- a/src/scripts/directives/snap-toggle.js
+++ b/src/scripts/directives/snap-toggle.js
@@ -1,0 +1,14 @@
+angular.module('snap')
+  .directive('snapToggle', function() {
+      return function (scope, element, attr) {
+        element.bind('click', function() {
+            if (element.scope().snapper !== undefined) {
+              if (attr.snapToggle) {
+                element.scope().snapper.toggle(attr.snapToggle);
+              } else {
+                element.scope().snapper.toggle('left');
+              }
+            }
+        });
+      }
+  });


### PR DESCRIPTION
Adds the snap-toggle attribute to easily attach a click event to an element to toggle the behaviour of the specified snap.
